### PR TITLE
Added the ability to purge by Surrogate-Key

### DIFF
--- a/src/main/scala/com/gu/fastly/api/FastlyApiClient.scala
+++ b/src/main/scala/com/gu/fastly/api/FastlyApiClient.scala
@@ -47,6 +47,10 @@ case class FastlyApiClient(apiKey: String, serviceId: String, config: Option[Asy
     val apiUrl = s"$fastlyApiUrl/purge/$urlWithoutPrefix"
     AsyncHttpExecutor.execute(apiUrl, POST, headers = Map("X-Fastly-Key" -> apiKey) ++ extraHeaders)
   }
+  def purgeKey(service:String, key:String, extraHeaders: Map[String, String] = Map.empty) = {
+    val apiUrl = s"${fastlyApiUrl}/service/$service/purge/$key"
+    AsyncHttpExecutor.execute(apiUrl, POST, headers = Map("X-Fastly-Key" -> apiKey) ++ extraHeaders)
+  }
 
   def versionCreate(): Future[Response] = {
     val apiUrl = s"$fastlyApiUrl/service/$serviceId/version"


### PR DESCRIPTION
Can now hit API to purge by Surrogate-Key. Super handy for bulk purges from Fastly.
