### PR TITLE
Expose Purge-All to Clients

### DIFF
--- a/src/main/scala/com/gu/fastly/api/FastlyApiClient.scala
+++ b/src/main/scala/com/gu/fastly/api/FastlyApiClient.scala
@@ -48,6 +48,11 @@ case class FastlyApiClient(apiKey: String, serviceId: String, config: Option[Asy
     AsyncHttpExecutor.execute(apiUrl, POST, headers = Map("X-Fastly-Key" -> apiKey) ++ extraHeaders)
   }
 
+  def purgeAll(): Future[Response] = {
+    val apiUrl = s"$fastlyApiUrl/service/$serviceId/purge_all"
+    AsyncHttpExecutor.execute(apiUrl, POST, headers = commonHeaders)
+  }
+
   def versionCreate(): Future[Response] = {
     val apiUrl = s"$fastlyApiUrl/service/$serviceId/version"
     AsyncHttpExecutor.execute(apiUrl, PUT, headers = commonHeaders)


### PR DESCRIPTION
So that we can entirely clear the cache on beta.theguardian.com before running tests.
http://docs.fastly.com/api/purge#purge_2

@obrienm 
