### PR TITLE
Use Fastly-Key instead of X-Fastly-Key

### DIFF
--- a/src/main/scala/com/gu/fastly/api/FastlyApiClient.scala
+++ b/src/main/scala/com/gu/fastly/api/FastlyApiClient.scala
@@ -10,7 +10,7 @@ import scala.util.Success
 case class FastlyApiClient(apiKey: String, serviceId: String, config: Option[AsyncHttpClientConfig] = None, proxyServer: Option[ProxyServer] = None) {
 
   private val fastlyApiUrl = "https://api.fastly.com"
-  private val commonHeaders = Map("X-Fastly-Key" -> apiKey, "Accept" -> "application/json")
+  private val commonHeaders = Map("Fastly-Key" -> apiKey, "Accept" -> "application/json")
 
   sealed trait HttpMethod
   object GET extends HttpMethod


### PR DESCRIPTION
The new header is Fastly-Key and per-user API keys don't work with the old way.

@JustinPinner @desbo that explains why you couldn't deploy from sbt