### PR TITLE
Update to Scala 2.11 and ship 0.2.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ organization := "com.gu"
 
 scalaVersion := "2.11.4"
 
-crossScalaVersions := Seq("2.10.4", "2.11.4")
+crossScalaVersions := Seq("2.10.4", "2.11.8")
 
 libraryDependencies ++= Seq(
     "com.ning" % "async-http-client" % "1.8.14",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.5"
+version in ThisBuild := "0.2.6-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.5-SNAPSHOT"
+version in ThisBuild := "0.2.5"


### PR DESCRIPTION
following on from the previous PR I have shipped a version we can use with https://github.com/guardian/fastly-edge-cache