### PR TITLE
Adds user agent to commonHeaders

### DIFF
--- a/src/main/scala/com/gu/fastly/api/FastlyApiClient.scala
+++ b/src/main/scala/com/gu/fastly/api/FastlyApiClient.scala
@@ -10,7 +10,7 @@ import scala.util.Success
 case class FastlyApiClient(apiKey: String, serviceId: String, config: Option[AsyncHttpClientConfig] = None, proxyServer: Option[ProxyServer] = None) {
 
   private val fastlyApiUrl = "https://api.fastly.com"
-  private val commonHeaders = Map("Fastly-Key" -> apiKey, "Accept" -> "application/json")
+  private val commonHeaders = Map("Fastly-Key" -> apiKey, "Accept" -> "application/json", "User-Agent" -> "fastly-scala")
 
   sealed trait HttpMethod
   object GET extends HttpMethod


### PR DESCRIPTION
Ideally, we'd like the value of the user agent to be something like "fastly-scala-v[VERSION OF LIBRARY]". I don't know scala very well. Mind pointing me in the right direction there?
