### PR TITLE
Fix vcl uploads

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.12.2"
 crossScalaVersions := Seq(scalaVersion.value, "2.11.9")
 
 libraryDependencies ++= Seq(
-    "com.ning" % "async-http-client" % "1.9.40",
+    "org.asynchttpclient" % "async-http-client" % "2.10.1",
     "joda-time" % "joda-time" % "2.5",
     "org.joda" % "joda-convert" % "1.7",
     "org.scalatest" %% "scalatest" % "3.0.3" % "test",

--- a/src/test/scala/com/gu/fastly/api/FastlyApiClientTest.scala
+++ b/src/test/scala/com/gu/fastly/api/FastlyApiClientTest.scala
@@ -106,6 +106,16 @@ class FastlyApiClientTest extends FeatureSpec with Matchers {
     }
   }
 
+    // this test is useful for e.g. testing massive vcl uploads, but requires write credentials to fastly
+//  feature ("vcl") {
+//    scenario("upload vcl") {
+//      val vcl = s"vcl_fetch { set var.testVar= ${List.fill(200000)("a").mkString("")}  }"
+//      val response = Await.result(client.vclUpload(10,vcl ,"err", "error.vcl"), 10.seconds)
+//      println(response.getResponseBody)
+//      assert(response.getStatusCode === 200)
+//    }
+//  }
+
   feature("Servcie") {
     scenario("list") {
       val response = Await.result(client.serviceList(), 5.seconds)

--- a/src/test/scala/com/gu/fastly/api/FastlyApiClientTest.scala
+++ b/src/test/scala/com/gu/fastly/api/FastlyApiClientTest.scala
@@ -106,16 +106,6 @@ class FastlyApiClientTest extends FeatureSpec with Matchers {
     }
   }
 
-    // this test is useful for e.g. testing massive vcl uploads, but requires write credentials to fastly
-//  feature ("vcl") {
-//    scenario("upload vcl") {
-//      val vcl = s"vcl_fetch { set var.testVar= ${List.fill(200000)("a").mkString("")}  }"
-//      val response = Await.result(client.vclUpload(10,vcl ,"err", "error.vcl"), 10.seconds)
-//      println(response.getResponseBody)
-//      assert(response.getStatusCode === 200)
-//    }
-//  }
-
   feature("Servcie") {
     scenario("list") {
       val response = Await.result(client.serviceList(), 5.seconds)


### PR DESCRIPTION
We were previously trying to fit vcl uploads into the query string - not too smart and causes our http client to crash once the vcl gets to a certain length. Before I realised we were doing this I tried upgrading the http client to see if it helped, which it didn't, but we now have upgraded http woohoo. The key bit in this change is where we do `setBody`