### PR TITLE
Scala 2.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 project/project
 .idea/
 .idea_modules/
+.bsp/

--- a/build.sbt
+++ b/build.sbt
@@ -3,15 +3,15 @@ name := "fastly-api-client"
 
 organization := "com.gu"
 
-scalaVersion := "2.12.2"
+scalaVersion := "2.13.7"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.11.9")
+crossScalaVersions := Seq(scalaVersion.value, "2.12.15")
 
 libraryDependencies ++= Seq(
     "org.asynchttpclient" % "async-http-client" % "2.10.1",
     "joda-time" % "joda-time" % "2.5",
     "org.joda" % "joda-convert" % "1.7",
-    "org.scalatest" %% "scalatest" % "3.0.3" % "test",
+    "org.scalatest" %% "scalatest" % "3.2.10" % "test",
     "com.typesafe" % "config" % "1.2.1" % "test"
 )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.5.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.5")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
+
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/src/test/scala/com/gu/fastly/api/FastlyApiClientTest.scala
+++ b/src/test/scala/com/gu/fastly/api/FastlyApiClientTest.scala
@@ -1,20 +1,21 @@
 package com.gu.fastly.api
 
-import org.joda.time.DateTime
-import org.scalatest.FeatureSpec
-import org.scalatest.Matchers
 import com.typesafe.config.ConfigFactory
+import org.joda.time.DateTime
+import org.scalatest.featurespec.AnyFeatureSpec
+import org.scalatest.matchers.must.Matchers
+
 import java.io.File
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class FastlyApiClientTest extends FeatureSpec with Matchers {
+class FastlyApiClientTest extends AnyFeatureSpec with Matchers {
 
   lazy val client = FastlyApiClient(conf.getString("apiKey"), conf.getString("serviceId"))
 
-  feature("stats") {
+  Feature("stats") {
 
-    scenario("stats") {
+    Scenario("stats") {
       val response = Await.result(client.stats(
         from = DateTime.now.minusMinutes(1),
         to = DateTime.now,
@@ -24,7 +25,7 @@ class FastlyApiClientTest extends FeatureSpec with Matchers {
       assert(response.getStatusCode === 200)
     }
 
-    scenario("stats with field filter") {
+    Scenario("stats with field filter") {
       val response = Await.result(client.statsWithFieldFilter(
         from = DateTime.now.minusMinutes(1),
         to = DateTime.now,
@@ -35,7 +36,7 @@ class FastlyApiClientTest extends FeatureSpec with Matchers {
       assert(response.getStatusCode === 200)
     }
 
-    scenario("aggregate") {
+    Scenario("aggregate") {
       val response = Await.result(client.statsAggregate(
         from = DateTime.now.minusMinutes(1),
         to = DateTime.now,
@@ -45,7 +46,7 @@ class FastlyApiClientTest extends FeatureSpec with Matchers {
       assert(response.getStatusCode === 200)
     }
 
-    scenario("service") {
+    Scenario("service") {
       val response = Await.result(client.statsForService(
         from = DateTime.now.minusMinutes(1),
         to = DateTime.now,
@@ -56,7 +57,7 @@ class FastlyApiClientTest extends FeatureSpec with Matchers {
       assert(response.getStatusCode === 200)
     }
 
-    scenario("service with field filter") {
+    Scenario("service with field filter") {
       val response = Await.result(client.statsForServiceWithFieldFilter(
         from = DateTime.now.minusMinutes(1),
         to = DateTime.now,
@@ -68,7 +69,7 @@ class FastlyApiClientTest extends FeatureSpec with Matchers {
       assert(response.getStatusCode === 200)
     }
 
-    scenario("usage") {
+    Scenario("usage") {
       val response = Await.result(client.statsUsage(
         from = DateTime.now.minusHours(1),
         to = DateTime.now,
@@ -78,7 +79,7 @@ class FastlyApiClientTest extends FeatureSpec with Matchers {
       assert(response.getStatusCode === 200)
     }
 
-    scenario("usage by grouped by service") {
+    Scenario("usage by grouped by service") {
       val response = Await.result(client.statsUsageGroupedByService(
         from = DateTime.now.minusHours(1),
         to = DateTime.now,
@@ -88,7 +89,7 @@ class FastlyApiClientTest extends FeatureSpec with Matchers {
       assert(response.getStatusCode === 200)
     }
 
-    scenario("regions") {
+    Scenario("regions") {
       val response = Await.result(client.stats(
         from = DateTime.now.minusMinutes(1),
         to = DateTime.now,
@@ -99,15 +100,15 @@ class FastlyApiClientTest extends FeatureSpec with Matchers {
       assert(response.getStatusCode === 200)
     }
 
-    scenario("stats region list") {
+    Scenario("stats region list") {
       val response = Await.result(client.statsRegions(), 5.seconds)
       //      println(response.getResponseBody)
       assert(response.getStatusCode === 200)
     }
   }
 
-  feature("Servcie") {
-    scenario("list") {
+  Feature("Servcie") {
+    Scenario("list") {
       val response = Await.result(client.serviceList(), 5.seconds)
       //            println(response.getResponseBody)
       assert(response.getStatusCode === 200)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.1-SNAPSHOT"
+ThisBuild / version := "0.4.1"


### PR DESCRIPTION
## What does this change?

A new 0.41 release for 2.13 (cross-publised to 2.12). Scala 2.11 is no longer supported.

## How to test

[(Now in Maven.)](https://search.maven.org/artifact/com.gu/fastly-api-client_2.13/0.4.1/jar)

## How can we measure success?

A 2.13 version is published in Maven!
