### PR TITLE
Cross-compile for Scala 3, as well as Scala 2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ organization := "com.gu"
 
 scalaVersion := "2.13.10"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.12.17")
+crossScalaVersions := Seq(scalaVersion.value, "2.12.17", "3.2.1")
 
 libraryDependencies ++= Seq(
     "org.asynchttpclient" % "async-http-client" % "2.12.3",
@@ -15,7 +15,11 @@ libraryDependencies ++= Seq(
     "com.typesafe" % "config" % "1.4.2" % Test
 )
 
-ThisBuild / scalacOptions ++= Seq("-Xsource:3", "-deprecation", "-feature", "-language:postfixOps")
+ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-language:postfixOps") ++
+  (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, _)) => Seq("-Xsource:3") // flags only needed in Scala 2
+    case _ => Seq.empty
+  })
 
 enablePlugins(BuildInfoPlugin)
 buildInfoKeys := Seq[BuildInfoKey](name, version)


### PR DESCRIPTION
This library is used by https://github.com/guardian/fastly-edge-cache for deploy & tests, and that project was recently updated to Scala 3 with https://github.com/guardian/fastly-edge-cache/pull/935.

We were able to use `CrossVersion.for3Use2_13` so that the `fastly-edge-cache` upgrade [_wasn't_](https://github.com/guardian/fastly-edge-cache/pull/935#discussion_r1013046273) blocked by `fastly-api-client` only supporting Scala 2.13 - however, that config tweak will no longer be necessary once `fastly-api-client` is compiled for Scala 3.

We should probably drop support for Scala 2.12 soon - it's almost certainly not needed!
