### PR TITLE
Bump netty-codec from 4.1.60.Final to 4.1.68.Final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,10 +8,8 @@ scalaVersion := "2.13.10"
 crossScalaVersions := Seq(scalaVersion.value, "2.12.17", "3.2.1")
 
 libraryDependencies ++= Seq(
-    "org.asynchttpclient" % "async-http-client" % "2.12.3" excludeAll (
-      ExclusionRule("io.netty", "netty-handler"),
-      ),
-    "io.netty" % "netty-handler" % "4.1.68.Final",
+    "org.asynchttpclient" % "async-http-client" % "2.12.3" exclude("io.netty", "netty-codec"),
+    "io.netty" % "netty-codec" % "4.1.68.Final",
     "joda-time" % "joda-time" % "2.12.1",
     "org.joda" % "joda-convert" % "2.2.2",
     "org.scalatest" %% "scalatest" % "3.2.14" % Test,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Creates an exclusion rule to bump transitive dependency netty from 4.1.60.Final to 4.1.68.Final to resolve the snyk high vulns.

Tests are passing 
<img width="394" alt="image" src="https://user-images.githubusercontent.com/110032454/225041972-6898998a-6228-4b60-86fe-ea8e8509cb99.png">


<img width="790" alt="image" src="https://user-images.githubusercontent.com/110032454/225041726-b4f6ea19-48ea-4abc-ad3f-840e90fa23eb.png">

