### PR TITLE
(feat) Add method to update version description

### DIFF
--- a/src/main/scala/com/gu/fastly/api/FastlyApiClient.scala
+++ b/src/main/scala/com/gu/fastly/api/FastlyApiClient.scala
@@ -123,6 +123,22 @@ case class FastlyApiClient(apiKey: String, serviceId: String, config: Option[Asy
     AsyncHttpExecutor.execute(apiUrl, headers = commonHeaders)
   }
 
+  /**
+   * Update an existing version with a comment that will appear in the Fastly web interface.
+   * Endpoint: PUT /service/:service_id/version/:version
+   * Official documentation: https://developer.fastly.com/reference/api/services/version/
+   *
+   * @param version Integer identifying a service version.
+   * @param comment A freeform descriptive note. This will appear in the service summary.
+   * @return
+   */
+  def versionComment(version: Int, comment: String): Future[Response] = {
+    val apiUrl = s"$fastlyApiUrl/service/$serviceId/version/$version"
+    val headers = Map("Content-Type" -> "application/x-www-form-urlencoded")
+    val params = Map("comment" -> comment)
+    AsyncHttpExecutor.execute(apiUrl, PUT, headers = commonHeaders ++ headers, parameters = params)
+  }
+
   def vclSetAsMain(version: Int, name: String): Future[Response] = {
     val apiUrl = s"$fastlyApiUrl/service/$serviceId/version/$version/vcl/$name/main"
     AsyncHttpExecutor.execute(apiUrl, PUT, headers = commonHeaders)


### PR DESCRIPTION
## What does this change?

Adds a new method to the client to allow adding descriptions to specific version of Fastly services.

This is useful because we now deploy a Compute@Edge application via Riff-Raff, and it would be great to add a comment such as "Deployed via Riff-Raff build number X by Y at timestamp Z" during deployment. 
This suggestion came from @SHession and @davidfurey so credit goes to them! :-)


## How to test

Updated version 41 of our service using this newly-added method.
<img width="1430" alt="image" src="https://user-images.githubusercontent.com/57295823/236487157-9249becb-9d58-4014-8051-10e77afe182a.png">

## How can we measure success?

Better audit trail.
