### PR TITLE
Upgrade to java 21

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '21'
           cache: 'sbt'
 
       - name: Build

--- a/build.sbt
+++ b/build.sbt
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
     "com.typesafe" % "config" % "1.4.3" % Test
 )
 
-ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-language:postfixOps") ++
+ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature", "-language:postfixOps", "-release", "11") ++
   (CrossVersion.partialVersion(scalaVersion.value) match {
     case Some((2, _)) => Seq("-Xsource:3") // flags only needed in Scala 2
     case _ => Seq.empty


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
Closes https://github.com/guardian/fastly-api-client/issues/40

## What does this change?

* Upgrade to Java 21
* Keep compatibility with Java 11