### PR TITLE
Remove duplicate version from crossScalaVersions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ organization := "com.gu"
 
 scalaVersion := "3.3.3"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.12.19", "2.13.14", "3.3.3")
+crossScalaVersions := Seq(scalaVersion.value, "2.12.19", "2.13.14")
 
 libraryDependencies ++= Seq(
     "org.asynchttpclient" % "async-http-client" % "2.12.3" exclude("io.netty", "netty-codec"),


### PR DESCRIPTION
When the scalaVersion was updated to 3.3.3, we missed that this version is now in crossScalaVersions twice! While this doesn’t fail the build, it does break scala-steward (as you can see [here](https://github.com/guardian/scala-steward-public-repos/actions/runs/9993840045/job/27622190386)). This PR removes the duplicate version to get scala-steward passing again.