### PR TITLE
Run compile and test in CI for all scala versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ libraryDependencies ++= Seq(
     "io.netty" % "netty-codec" % "4.1.111.Final",
     "joda-time" % "joda-time" % "2.12.7",
     "org.joda" % "joda-convert" % "2.2.3",
+    "org.scala-lang.modules" %% "scala-collection-compat" % "2.12.0",
     "org.scalatest" %% "scalatest" % "3.2.19" % Test,
     "com.typesafe" % "config" % "1.4.3" % Test
 )

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-sbt clean compile test
+sbt clean +compile +test


### PR DESCRIPTION
The project specifies a number of scala versions in its build.sbt, but before now CI was running `compile` and `test`, which only use the current scala version. This meant it was possible for CI to pass if the code compiled successfully in the current version but failed in one of the versions in `crossScalaVersions`.

This PR updates the CI script to use `+compile` and `+test`, which run those tasks for all versions in `crossScalaVersions`. It also adds a dependency on `scala-collection-compat` to fix compilation for scala 2.12.