### PR TITLE
Disable tests in release action

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,6 @@ releaseProcess := Seq[ReleaseStep](
   checkSnapshotDependencies,
   inquireVersions,
   runClean,
-  runTest,
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,


### PR DESCRIPTION
They need credentials and the release action does not have access to them. Tests have already passed in the build in order to merge the PR.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->
