### PR TITLE
Use `guardian/setup-scala` workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,12 +13,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup java
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'corretto'
-          java-version: '21'
-          cache: 'sbt'
+      # See https://github.com/guardian/setup-java
+      - name: Setup Java and sbt
+        uses: guardian/setup-scala@v1
 
       - name: Build
         env:


### PR DESCRIPTION
Using the Guardian-provided setup-scala workflow allows us to configure and install Java and sbt at the same time.

We need this because GitHub no longer includes "sbt" in its base images, so we have to set it up separately.

See https://github.com/guardian/amiable/pull/738 for another example.

Paired with @marjisound @SiAdcock @DanielCliftonGuardian @frederickobrien @domlander 
