### PR TITLE
Test release workflow with setup sbt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   release:
-    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@main
+    uses: guardian/gha-scala-library-release-workflow/.github/workflows/reusable-release.yml@add-setup-sbt-action
     permissions: { contents: write, pull-requests: write }
     secrets:
       SONATYPE_TOKEN: ${{ secrets.AUTOMATED_MAVEN_RELEASE_SONATYPE_TOKEN }}


### PR DESCRIPTION
We've added `setup-sbt` to the release workflow on a branch in that repo. We're going to test that it works by releasing `fastly-api-client` with that branch in this repo.
