### PR TITLE
Fix version-number confusion - skip straight to v1.0.0!

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-ThisBuild / version := "0.4.9-SNAPSHOT"
+ThisBuild / version := "1.0.0-SNAPSHOT"


### PR DESCRIPTION
This library has had some [version-number confusion](https://index.scala-lang.org/guardian/fastly-api-client/artifacts/fastly-api-client?stable-only=true#):

* [v0.4.4](https://github.com/guardian/fastly-api-client/releases/tag/v0.4.4) - 2023/03/17 - updated `version.sbt`
* **v0.5.0** - 2023/04/28 - did not update `version.sbt` (`git` [tag](https://github.com/guardian/fastly-api-client/releases/tag/v0.5.0))
* **v0.6.0** - 2023/05/05 - did not update `version.sbt` (and didn't get a `git` tag)
* [v0.4.5](https://github.com/guardian/fastly-api-client/releases/tag/v0.4.5) - 2024/07/26 - picked up this _smaller_ version number based on what was in `version.sbt`
* [v0.4.6](https://github.com/guardian/fastly-api-client/releases/tag/v0.4.6) - 2023/07/30 - released as normal
* ...etc

This repo adopted [`gha-scala-library-release-workflow`](https://github.com/guardian/gha-scala-library-release-workflow) with https://github.com/guardian/fastly-api-client/pull/47 and [v0.4.5](https://github.com/guardian/fastly-api-client/releases/tag/v0.4.5) in 2024/07/26 - before that the release procedure was much more manual & error-prone!

To get past the confusion, it's best to jump to a version number higher than 0.6.0 - and as this library, like all libraries that use `gha-scala-library-release-workflow`, is using `early-semver`, it makes sense to move past 0.y.z as a version number - under `early-semver`:

> When the major version is 0, a minor version increment MAY contain both source and binary breakages, but a patch version increment MUST remain binary compatible.

To avoid the complication of trying to understand that, better to just get to v1 and above!
