### PR TITLE
Replace Joda time with Java time

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,6 @@ crossScalaVersions := Seq(scalaVersion.value, "2.12.20", "2.13.15")
 
 libraryDependencies ++= Seq(
     "org.asynchttpclient" % "async-http-client" % "3.0.2",
-    "joda-time" % "joda-time" % "2.13.0",
-    "org.joda" % "joda-convert" % "2.2.4",
     "org.scala-lang.modules" %% "scala-collection-compat" % "2.12.0",
     "org.scalatest" %% "scalatest" % "3.2.19" % Test,
     "com.typesafe" % "config" % "1.4.3" % Test

--- a/src/main/scala/com/gu/fastly/api/FastlyApiClient.scala
+++ b/src/main/scala/com/gu/fastly/api/FastlyApiClient.scala
@@ -5,7 +5,6 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import org.asynchttpclient.*
 import org.asynchttpclient.proxy.ProxyServer
-import org.joda.time.DateTime
 
 import scala.concurrent.{Future, Promise}
 import scala.language.implicitConversions
@@ -13,7 +12,7 @@ import scala.util.Success
 import org.asynchttpclient.Dsl.*
 import org.asynchttpclient.request.body.multipart.{FilePart, Part}
 
-import java.time.Duration
+import java.time.{Duration, Instant}
 
 // http://docs.fastly.com/api
 case class FastlyApiClient(apiKey: String, serviceId: String, config: Option[AsyncHttpClientConfig] = None, proxyServer: Option[ProxyServer] = None) {
@@ -176,43 +175,43 @@ case class FastlyApiClient(apiKey: String, serviceId: String, config: Option[Asy
     AsyncHttpExecutor.execute(apiUrl, headers = commonHeaders)
   }
 
-  def stats(from: DateTime, to: DateTime, by: By.Value, region: Region.Value = Region.all): Future[Response] = {
+  def stats(from: Instant, to: Instant, by: By.Value, region: Region.Value = Region.all): Future[Response] = {
     val apiUrl = s"$fastlyApiUrl/stats"
     val params = statsParams(from, to, by, region)
     AsyncHttpExecutor.execute(apiUrl, headers = commonHeaders, parameters = params)
   }
 
-  def statsWithFieldFilter(from: DateTime, to: DateTime, by: By.Value, region: Region.Value = Region.all, field: String): Future[Response] = {
+  def statsWithFieldFilter(from: Instant, to: Instant, by: By.Value, region: Region.Value = Region.all, field: String): Future[Response] = {
     val apiUrl = s"$fastlyApiUrl/stats/field/$field"
     val params = statsParams(from, to, by, region)
     AsyncHttpExecutor.execute(apiUrl, headers = commonHeaders, parameters = params)
   }
 
-  def statsAggregate(from: DateTime, to: DateTime, by: By.Value, region: Region.Value = Region.all): Future[Response] = {
+  def statsAggregate(from: Instant, to: Instant, by: By.Value, region: Region.Value = Region.all): Future[Response] = {
     val apiUrl = s"$fastlyApiUrl/stats/aggregate"
     val params = statsParams(from, to, by, region)
     AsyncHttpExecutor.execute(apiUrl, headers = commonHeaders, parameters = params)
   }
 
-  def statsForService(from: DateTime, to: DateTime, by: By.Value, region: Region.Value = Region.all, serviceId: String): Future[Response] = {
+  def statsForService(from: Instant, to: Instant, by: By.Value, region: Region.Value = Region.all, serviceId: String): Future[Response] = {
     val apiUrl = s"$fastlyApiUrl/stats/service/$serviceId"
     val params = statsParams(from, to, by, region)
     AsyncHttpExecutor.execute(apiUrl, headers = commonHeaders, parameters = params)
   }
 
-  def statsForServiceWithFieldFilter(from: DateTime, to: DateTime, by: By.Value, region: Region.Value = Region.all, serviceId: String, field: String): Future[Response] = {
+  def statsForServiceWithFieldFilter(from: Instant, to: Instant, by: By.Value, region: Region.Value = Region.all, serviceId: String, field: String): Future[Response] = {
     val apiUrl = s"$fastlyApiUrl/stats/service/$serviceId/field/$field"
     val params = statsParams(from, to, by, region)
     AsyncHttpExecutor.execute(apiUrl, headers = commonHeaders, parameters = params)
   }
 
-  def statsUsage(from: DateTime, to: DateTime, by: By.Value, region: Region.Value = Region.all): Future[Response] = {
+  def statsUsage(from: Instant, to: Instant, by: By.Value, region: Region.Value = Region.all): Future[Response] = {
     val apiUrl = s"$fastlyApiUrl/stats/usage"
     val params = statsParams(from, to, by, region)
     AsyncHttpExecutor.execute(apiUrl, headers = commonHeaders, parameters = params)
   }
 
-  def statsUsageGroupedByService(from: DateTime, to: DateTime, by: By.Value, region: Region.Value = Region.all): Future[Response] = {
+  def statsUsageGroupedByService(from: Instant, to: Instant, by: By.Value, region: Region.Value = Region.all): Future[Response] = {
     val apiUrl = s"$fastlyApiUrl/stats/usage_by_service"
     val params = statsParams(from, to, by, region)
     AsyncHttpExecutor.execute(apiUrl, headers = commonHeaders, parameters = params)
@@ -223,9 +222,9 @@ case class FastlyApiClient(apiKey: String, serviceId: String, config: Option[Asy
     AsyncHttpExecutor.execute(apiUrl, headers = commonHeaders)
   }
 
-  private def statsParams(from: DateTime, to: DateTime, by: By.Value, region: Region.Value = Region.all): Map[String, String] = {
-    def millis(date: DateTime): String = (date.getMillis / 1000).toString
-    Map[String, String]("from" -> millis(from), "to" -> millis(to), "by" -> by.toString, "region" -> region.toString)
+  private def statsParams(from: Instant, to: Instant, by: By.Value, region: Region.Value = Region.all): Map[String, String] = {
+    def seconds(date: Instant): String = date.getEpochSecond.toString
+    Map[String, String]("from" -> seconds(from), "to" -> seconds(to), "by" -> by.toString, "region" -> region.toString)
   }
 
   def closeConnectionPool() = AsyncHttpExecutor.close()

--- a/src/test/scala/com/gu/fastly/api/FastlyApiClientTest.scala
+++ b/src/test/scala/com/gu/fastly/api/FastlyApiClientTest.scala
@@ -1,13 +1,14 @@
 package com.gu.fastly.api
 
 import com.typesafe.config.{ConfigException, ConfigFactory}
-import org.joda.time.DateTime
 import org.scalatest.featurespec.AnyFeatureSpec
 import org.scalatest.matchers.must.Matchers
 
 import java.io.File
+import java.time.Instant
 import scala.concurrent.Await
 import scala.concurrent.duration._
+import java.time.temporal.ChronoUnit.{HOURS, MINUTES}
 
 class FastlyApiClientTest extends AnyFeatureSpec with Matchers {
 
@@ -21,8 +22,8 @@ class FastlyApiClientTest extends AnyFeatureSpec with Matchers {
 
     Scenario("stats") {
       val response = Await.result(client.stats(
-        from = DateTime.now.minusMinutes(1),
-        to = DateTime.now,
+        from = Instant.now.minus(1, MINUTES),
+        to = Instant.now,
         by = By.minute
       ), 5.seconds)
       //      println(response.getResponseBody)
@@ -31,8 +32,8 @@ class FastlyApiClientTest extends AnyFeatureSpec with Matchers {
 
     Scenario("stats with field filter") {
       val response = Await.result(client.statsWithFieldFilter(
-        from = DateTime.now.minusMinutes(1),
-        to = DateTime.now,
+        from = Instant.now.minus(1, MINUTES),
+        to = Instant.now,
         by = By.minute,
         field = "hit_ratio"
       ), 5.seconds)
@@ -42,8 +43,8 @@ class FastlyApiClientTest extends AnyFeatureSpec with Matchers {
 
     Scenario("aggregate") {
       val response = Await.result(client.statsAggregate(
-        from = DateTime.now.minusMinutes(1),
-        to = DateTime.now,
+        from = Instant.now.minus(1, MINUTES),
+        to = Instant.now,
         by = By.minute
       ), 5.seconds)
       //      println(response.getResponseBody)
@@ -52,8 +53,8 @@ class FastlyApiClientTest extends AnyFeatureSpec with Matchers {
 
     Scenario("service") {
       val response = Await.result(client.statsForService(
-        from = DateTime.now.minusMinutes(1),
-        to = DateTime.now,
+        from = Instant.now.minus(1, MINUTES),
+        to = Instant.now,
         by = By.minute,
         serviceId = client.serviceId
       ), 5.seconds)
@@ -63,8 +64,8 @@ class FastlyApiClientTest extends AnyFeatureSpec with Matchers {
 
     Scenario("service with field filter") {
       val response = Await.result(client.statsForServiceWithFieldFilter(
-        from = DateTime.now.minusMinutes(1),
-        to = DateTime.now,
+        from = Instant.now.minus(1, MINUTES),
+        to = Instant.now,
         by = By.minute,
         serviceId = client.serviceId,
         field = "hit_ratio"
@@ -75,8 +76,8 @@ class FastlyApiClientTest extends AnyFeatureSpec with Matchers {
 
     Scenario("usage") {
       val response = Await.result(client.statsUsage(
-        from = DateTime.now.minusHours(1),
-        to = DateTime.now,
+        from = Instant.now.minus(1, HOURS),
+        to = Instant.now,
         by = By.minute
       ), 5.seconds)
       //      println(response.getResponseBody)
@@ -85,8 +86,8 @@ class FastlyApiClientTest extends AnyFeatureSpec with Matchers {
 
     Scenario("usage by grouped by service") {
       val response = Await.result(client.statsUsageGroupedByService(
-        from = DateTime.now.minusHours(1),
-        to = DateTime.now,
+        from = Instant.now.minus(1, HOURS),
+        to = Instant.now,
         by = By.minute
       ), 5.seconds)
       //      println(response.getResponseBody)
@@ -95,8 +96,8 @@ class FastlyApiClientTest extends AnyFeatureSpec with Matchers {
 
     Scenario("regions") {
       val response = Await.result(client.stats(
-        from = DateTime.now.minusMinutes(1),
-        to = DateTime.now,
+        from = Instant.now.minus(1, MINUTES),
+        to = Instant.now,
         by = By.minute,
         region = Region.all
       ), 5.seconds)


### PR DESCRIPTION
The advice from the Joda time project is that people should move to Java time, as detailed here:
https://github.com/guardian/maintaining-scala-projects/issues/18
