### PR TITLE
Add `.carabiner` to gitignore to fix release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ project/project
 .metals/
 .vscode/
 metals.sbt
+.carabiner/


### PR DESCRIPTION
The release is currently failing due to untracked files in this directory.

See also: https://github.com/guardian/content-api-models/pull/330
