### PR TITLE
Revert "Add `.carabiner` to gitignore to fix release"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ project/project
 .metals/
 .vscode/
 metals.sbt
-.carabiner/


### PR DESCRIPTION
Reverts guardian/fastly-api-client#166

See https://github.com/guardian/fastly-api-client/pull/166#issuecomment-5413296430
